### PR TITLE
Update Wordpress Test Version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link:       https://cmb2.io
 Tags:              metaboxes, forms, fields, options, settings
 Requires at least: 3.8.0
 Requires PHP:      5.2
-Tested up to:      5.3.2
+Tested up to:      5.6.0
 Stable tag:        2.7.0
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Fixes error message in WordPress plugin directory "This plugin hasn’t been tested with the latest 3 major releases of WordPress"

Fixes #{issue-number}.

### Changes proposed in this pull request

-  

-  

-  

